### PR TITLE
Startup script added and spotify key removed from the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# spotify-playlist-terraform
+# Atlantis & Terraform Spotify Playlist Automation
+
+This repository aims to automate the deployment of a Spotify playlist using **Terraform** and **Atlantis**, alongside **Spotify Auth Proxy** for secure API authentication. The goal is to automate the process of running `terraform plan` and `terraform apply` via Atlantis when changes are pushed to GitHub.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Setting Up GitHub](#setting-up-github)
+3. [Docker Setup](#docker-setup)
+4. [Environment Setup](#environment-setup)
+5. [Starting the Project](#starting-the-project)
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have the following tools installed:
+
+- Docker & Docker Compose
+- Spotify developer account (for `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`)
+- Terraform
+
+## Setting Up GitHub
+
+1. **Create a GitHub App**:
+
+   - Go to your GitHub account and navigate to **Settings > Developer Settings > GitHub Apps**.
+   - Click **New GitHub App** and follow the setup wizard.
+   - **Set permissions** for the app:
+     - Set **Repository permissions** to `Read & write` for **Contents** and **Pull requests**.
+     - Set **Organization permissions** to `Read` for **Members**, if applicable.
+   - Once the app is created, save the **App ID** and **Private Key** file (download the `.pem` file, you will use this for authentication).
+
+2. **Generate GitHub OAuth Token** (Note: In this case, the `.pem` file is used for authentication instead of a GitHub token).
+
+---
+
+# Configuring GitHub for Atlantis
+
+Atlantis requires a webhook in your repository to trigger `terraform plan` whenever someone opens a pull request (PR).
+
+## Steps in GitHub
+
+1. Go to **Settings** → **Webhooks** in your GitHub repository.
+2. Click **Add Webhook**.
+3. Configure the webhook with the following:
+   - **Payload URL**: `http://your_server:4141/events`
+   - **Content type**: `application/json`
+   - **Secret**: Leave this blank.
+   - **Which events?** → Select **Pull requests** and **Pushes**.
+4. Enable the webhook by clicking **Add Webhook**.
+
+This ensures that Atlantis will listen for events in the repository and execute `terraform plan` and `terraform apply` when a PR is opened or pushed.
+
+---
+
+## Docker Setup
+
+### Docker Compose Configuration
+
+This repository uses **Docker** to spin up Atlantis and the Spotify Auth Proxy. The `docker-compose.yml` file includes two services:
+
+1. **Atlantis**: Automates Terraform commands like `plan` and `apply`.
+2. **Spotify Auth Proxy**: A proxy that handles Spotify API authentication and provides an API key.
+
+### Networks Configuration
+
+Both services are on the same Docker network (`atlantis_default`), allowing communication between them. You can customize the network by modifying the `docker-compose.yml`.
+
+---
+
+## Environment Setup
+
+1. **Create a `.env` file** inside the `Atlantis` directory with the following variables:
+
+```env
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+GH_APP_ID=your_github_app_id
+```
+
+2. Place the GitHub App Key (the .pem file you downloaded earlier) inside the Atlantis directory, and update the docker-compose.yml to point to this file.
+
+---
+
+# Starting the project
+
+To start the project and automate the setup:
+
+1. Ensure your `.env` file is set up correctly with the necessary Spotify credentials and GitHub App ID.
+2. Run the `start.sh` script from the Atlantis directory:
+
+   ```bash
+   ./start.sh
+   ```
+
+## The script will automatically:
+
+- Start the containers using docker compose up.
+- Fetch the API Key and add it to terraform.tfvars.
+- Open the Spotify Auth URL in your default browser for authentication.
+- Once authenticated, Terraform is ready to be used with Atlantis.

--- a/atlantis/docker-compose.yml
+++ b/atlantis/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - atlantis_network
     ports:
       - "4141:4141"
+    env_file:
+      - .env
     volumes: 
       - /etc/atlantis/github-app-key.pem:/etc/atlantis/github-app-key.pem
       - ./terraform:/terraform
@@ -15,7 +17,7 @@ services:
     command: 
       - server 
       - --gh-app-key-file=/etc/atlantis/github-app-key.pem
-      - --gh-app-id=1157716
+      - --gh-app-id=${GH_APP_ID}
       - --repo-allowlist=github.com/angatupyry/spotify-playlist-terraform
       - --write-git-creds
     
@@ -24,9 +26,6 @@ services:
     container_name: spotify-auth-proxy
     ports:
       - "27228:27228"
-    environment:
-      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID}
-      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET}
     env_file:
       - .env  
     restart: unless-stopped

--- a/atlantis/start.sh
+++ b/atlantis/start.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+docker compose up -d
+
+# Wait a few seconds for the containers to initialize correctly
+sleep 5
+
+
+# Get the API Key from the `spotify-auth-proxy` container and write the API Key to `terraform.tfvars`
+CONTAINER_NAME="spotify-auth-proxy"
+API_KEY=$(docker logs "$CONTAINER_NAME" 2>&1 | grep "APIKey:" | tail -n1 | awk '{print $2}')
+
+if [[ -z "$API_KEY" ]]; then
+    echo "Error: Could not retrieve the API Key from Spotify Auth Proxy"
+    exit 1
+fi
+
+echo "spotify_api_key = \"$API_KEY\"" > "$(dirname "$0")/terraform/terraform.tfvars"
+
+# Get the authentication URL from the container logs
+AUTH_URL=$(docker logs "$CONTAINER_NAME" 2>&1 | grep "Auth URL:" | tail -n1 | awk '{print $3}')
+
+if [[ -z "$AUTH_URL" ]]; then
+    echo "Error: Could not retrieve the authentication URL from the logs"
+    exit 1
+fi
+
+# Open the URL in the browser automatically
+if command -v xdg-open &>/dev/null; then
+    xdg-open "$AUTH_URL"  # Linux
+elif command -v open &>/dev/null; then
+    open "$AUTH_URL"  # macOS
+elif command -v start &>/dev/null; then
+    start "$AUTH_URL"  # Windows
+else
+    echo "Could not open automatically, please copy and paste this URL into your browser:"
+    echo "$AUTH_URL"
+fi
+
+
+echo "Everything is working."

--- a/atlantis/stop.sh
+++ b/atlantis/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose down

--- a/atlantis/terraform/terraform.tfvars
+++ b/atlantis/terraform/terraform.tfvars
@@ -1,1 +1,1 @@
-spotify_api_key = "..."
+spotify_api_key = "IY42qIx89-frWjH41qPjQzmTFSdnPByq-yQgSIxDvMdABszd0le96AKfFR2cRm6C"

--- a/atlantis/terraform/terraform.tfvars
+++ b/atlantis/terraform/terraform.tfvars
@@ -1,1 +1,1 @@
-spotify_api_key = "tYwK4ag3grBOiQvJvIDR5EtU8S5qvw0tB7PBjJSvdbTrvhGpntSgCcPy0MG4m5Z6"
+spotify_api_key = "..."


### PR DESCRIPTION
- The spotify key must be added as a github variable to be obtained dynamically. For the purposes of this test the spotify key is commented out so that atlantis can authenticate. 
- Purpose of PR is to test atlantis plan and apply
- Update readme